### PR TITLE
Add gem configuration options

### DIFF
--- a/USAGES.md
+++ b/USAGES.md
@@ -1,0 +1,21 @@
+# Bitbond Ruby
+
+## Usages
+
+### Configure
+
+Once you have your API keys then you can configure the client as
+
+```ruby
+Bitbond.configure do |config|
+  config.app_id = "YOUR_APP_ID"
+  config.secret_key = "SECRET_KEY"
+end
+```
+
+Or
+
+```ruby
+Bitbond.configuration.app_id = "YOUR_APP_ID"
+Bitbond.configuration.secret_key = "SECRET_KEY"
+```

--- a/lib/bitbond/client.rb
+++ b/lib/bitbond/client.rb
@@ -1,15 +1,13 @@
 require 'oauth2'
+require "bitbond/configuration"
 
 module Bitbond
   class Client
 
-    attr_accessor :app_id, :secret, :token,  :base_url, :refresh_token, :expires_at
+    attr_accessor :token, :refresh_token, :expires_at
 
-    def initialize( app_id:, secret:, access_token:, refresh_token: nil, expires_at: nil, base_url: "https://www.bitbond.com")
-      self.app_id = app_id
-      self.secret = secret
+    def initialize(access_token:, refresh_token: nil, expires_at: nil)
       self.token = access_token
-      self.base_url = base_url
       self.refresh_token = refresh_token
       self.expires_at = expires_at
     end
@@ -85,11 +83,15 @@ module Bitbond
     end
 
     def url(endpoint)
-      "#{self.base_url}/api/v1/#{endpoint}"
+      [Bitbond.configuration.api_host, endpoint].join("/")
     end
 
     def oauth_client
-      @oauth_client ||= OAuth2::Client.new(app_id, secret, site: base_url)
+      @oauth_client ||= OAuth2::Client.new(
+        Bitbond.configuration.app_id,
+        Bitbond.configuration.secret_key,
+        site: Bitbond.configuration.api_host
+      )
     end
 
     def access_token

--- a/lib/bitbond/configuration.rb
+++ b/lib/bitbond/configuration.rb
@@ -1,0 +1,21 @@
+module Bitbond
+  class Configuration
+    attr_accessor :app_id, :secret_key, :api_host
+
+    def initialize
+      @api_host ||= "https://www.bitbond.com/api/v1"
+    end
+  end
+
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configuration=(config)
+    @configuration = config
+  end
+end

--- a/spec/bitbond/client_spec.rb
+++ b/spec/bitbond/client_spec.rb
@@ -103,15 +103,18 @@ describe Bitbond::Client do
     end
 
     it 'can search loans' do
-      stub_request(:get, "#{base_url}/loans?base_currency%5B%5D=usd&page=0&rating%5B%5D=A")
-        .to_return(mock_json_collection)
+      stub_request(
+        :get, api_url("loans?base_currency%5B%5D=usd&page=0&rating%5B%5D=A")
+      ).to_return(mock_json_collection)
 
       client.loans(base_currency: ['usd'], rating: ['A'])
     end
 
     it 'can search for term and accepts page arguments' do
-      stub_request(:get, "#{base_url}/loans?base_currency%5B%5D=btc&base_currency%5B%5D=usd&page=2&term%5B%5D=term_6_weeks")
-        .to_return(mock_json_collection)
+      stub_request(
+        :get,
+        api_url("loans?base_currency%5B%5D=btc&base_currency%5B%5D=usd&page=2&term%5B%5D=term_6_weeks")
+      ).to_return(mock_json_collection)
 
       client.loans(base_currency: ['usd', 'btc'], page: 2, term: ['term_6_weeks'])
     end
@@ -126,7 +129,7 @@ describe Bitbond::Client do
     end
 
     it 'can bid on a loan' do
-      url = "#{base_url}/loans/LOAN_ID/bids"
+      url = api_url("loans/LOAN_ID/bids")
       stub_request(:post, url).with(body: { bid: { amount: 0.1 }})
 
       client.bid(loan_id: "LOAN_ID", amount: 0.1)
@@ -169,7 +172,9 @@ describe Bitbond::Client do
 
   describe 'Refresh token' do
     subject(:client) {
-      Bitbond::Client.new(app_id: app_id, secret: secret, access_token: access_token, **{ refresh_token: 'REFRESH' } )
+      Bitbond::Client.new(
+        access_token: access_token, **{ refresh_token: 'REFRESH' }
+      )
     }
 
     it 'will be able to refresh the oauth token' do

--- a/spec/bitbond/configuration_spec.rb
+++ b/spec/bitbond/configuration_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe Bitbond::Configuration do
+  after { restore_default_config }
+
+  describe "#app_id" do
+    context "when app id configured" do
+      it "is used as app id" do
+        app_id = "app_id_123"
+        Bitbond.configure { |config| config.app_id = app_id }
+
+        expect(Bitbond.configuration.app_id).to eq(app_id)
+      end
+    end
+  end
+
+  describe "#secret_key" do
+    context "when secret_key configured" do
+      it "is used" do
+        secret_key = "bitbond-secret-key"
+        Bitbond.configure { |config| config.secret_key = secret_key }
+
+        expect(Bitbond.configuration.secret_key).to eq(secret_key)
+      end
+    end
+  end
+
+  describe "#api_host" do
+    context "when no api host specified" do
+      it "usages the deafult host" do
+        expect(
+          Bitbond.configuration.api_host
+        ).to eq("https://www.bitbond.com/api/v1")
+      end
+    end
+
+    context "when custom api host specified" do
+      it "use the custom host" do
+        custom_api_host = "http://custom-api-host.example.com"
+        Bitbond.configure {|config| config.api_host = custom_api_host }
+
+        expect(Bitbond.configuration.api_host).to eq(custom_api_host)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,12 @@ Bundler.setup
 
 require 'bitbond'
 
-def app_id
-  'APP_ID'
-end
 
-def secret
-  'SECRET'
+RSpec.configure do |config|
+  config.before :suite do
+    Bitbond.configuration.app_id = "APP_ID"
+    Bitbond.configuration.secret_key = "SECRET"
+  end
 end
 
 def access_token
@@ -17,11 +17,7 @@ def access_token
 end
 
 def bitbond_client
-  Bitbond::Client.new(app_id: app_id, secret: secret, access_token: access_token)
-end
-
-def base_url
-  "https://www.bitbond.com/api/v1"
+  Bitbond::Client.new(access_token: access_token)
 end
 
 def mock_item
@@ -33,7 +29,7 @@ def mock_collection
 end
 
 def api_url(endpoint)
-  "#{base_url}/#{endpoint}"
+  [Bitbond.configuration.api_host, endpoint].join("/")
 end
 
 def mock_json_collection
@@ -63,4 +59,7 @@ def test_get_collection(client, endpoint, method = endpoint)
   expect(a_request(:get, url)).to have_been_made
 end
 
-
+def restore_default_config
+  Bitbond.configuration = nil
+  Bitbond.configure {}
+end


### PR DESCRIPTION
Every time user needs a client instance, then they need to provide an app_id, secret_key, and api_host. But it can be simplified by providing a configuration option where they can set up their keys once, and the API client will handle the rest.

This commit changes the gem to be configurable and user can configure their keys as follow:

```ruby
Bitbond.configure do |config|
  config.api_host = "https://www.bitbond.com/api/v1"
  config.app_id = "APP_ID"
  config.secret_key = "SECRET_KEY"
end
```